### PR TITLE
chore: textlint-rule-preset-smarthr更新時にレビュー必須化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,9 @@
 {
-  "extends": ["github>book000/templates//renovate/base-public"]
+  "extends": ["github>book000/templates//renovate/base-public"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["textlint-rule-preset-smarthr"],
+      "reviewers": ["book000"]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- textlint-rule-preset-smarthrのrenovate更新PRに対して、book000のレビューを自動的に要求するよう設定
- renovate.jsonにpackageRulesを追加して実装

## 変更内容
renovate.jsonに以下の設定を追加：
- `packageRules`でtextlint-rule-preset-smarthrを指定
- `reviewers`にbook000を設定

これにより、textlint-rule-preset-smarthrの更新PRが作成された際に、自動的にbook000がレビュアーとして割り当てられます。

## 関連
- #406 のフォローアップ対応
- SmartHRルールの更新による影響を適切にレビューするため

🤖 Generated with [Claude Code](https://claude.ai/code)