### PR TITLE
docs: エージェント向けプロンプトファイルを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,37 +1,63 @@
-# CLAUDE.md
+# GitHub Copilot Instructions
 
+## プロジェクト概要
+Documentation repository for Zenn.dev that contains technical articles and books with Japanese language linting and quality checks.
 
-
-## プロジェクトの目的
-
-## 重要ルール
-- 会話言語: 日本語
+## 共通ルール
+- 会話は日本語で行う。
 - PR とコミットは Conventional Commits に従う。
 - PR タイトルとコミット本文の言語: PR タイトルは Conventional Commits 形式（英語推奨）。PR 本文は日本語。コミットは Conventional Commits 形式（description は日本語）。
-- コメント言語: 日本語
-- エラーメッセージ: 英語
 - 日本語と英数字の間には半角スペースを入れる。
 - 既存のプロジェクトルールがある場合はそれを優先する。
 
+## 技術スタック
+- 言語: Markdown, YAML
+- パッケージマネージャー: pnpm
+
 ## コーディング規約
+- フォーマット: 既存設定（ESLint / Prettier / formatter）に従う。
+- 命名規則: 既存のコード規約に従う。
+- Lint / Format: 既存の Lint / Format 設定に従う。
+- コメント言語: 日本語
+- エラーメッセージ: 英語
+- TypeScript 使用時は strict 前提とし、`skipLibCheck` で回避しない。
+- 関数やインターフェースには docstring（JSDoc など）を記載する。
 
-- コードスタイルは既存コードに従う
-
-## プロジェクト構成
-
-プロジェクト構成については README を確認してください。
-
-## 開発コマンド
-
+### 開発コマンド
 ```bash
-# 依存関係のインストール
+# install
 pnpm install
 
-# 開発 / テスト / Lint は README を確認してください
+# dev
+zenn preview --host 0.0.0.0
+
+# lint
+textlint articles/ books/
+
+# fix
+textlint --fix articles/ books/
+
 ```
 
-## 新機能実装時の注意事項
+## テスト方針
+- 新機能や修正には適切なテストを追加する。
 
-- 既存のコード構造とパターンを維持する
-- 適切なテストを追加する
-- ドキュメントを更新する
+## セキュリティ / 機密情報
+- 認証情報やトークンはコミットしない。
+- ログに機密情報を出力しない。
+
+## ドキュメント更新
+- 実装確定後、同一コミットまたは追加コミットで更新する。
+- README、API ドキュメント、コメント等は常に最新状態を保つ。
+
+## リポジトリ固有
+- **note**: Zenn.dev documentation with Japanese content
+- **platform**: Zenn.dev publishing platform
+**content_types:**
+  - articles
+  - books
+- **language_focus**: Japanese
+**quality_focus:**
+  - Japanese grammar and spacing
+  - Technical writing standards
+  - Consistency and accessibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,3 +25,13 @@
 - ログに機密情報を出力しない。
 
 ## リポジトリ固有
+- **note**: Zenn.dev documentation with Japanese content
+- **platform**: Zenn.dev publishing platform
+**content_types:**
+  - articles
+  - books
+- **language_focus**: Japanese
+**quality_focus:**
+  - Japanese grammar and spacing
+  - Technical writing standards
+  - Consistency and accessibility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,19 @@
 - 前提・仮定・不確実性を明示し、仮定を事実のように扱わない。
 
 ## プロジェクト概要
-- 目的: https://zenn.dev/book000
+Documentation repository for Zenn.dev that contains technical articles and books with Japanese language linting and quality checks.
+
+### 技術スタック
+- **言語**: Markdown, YAML
+- **フレームワーク**: Zenn CLI
+- **パッケージマネージャー**: pnpm
+- **主要な依存関係**:
+  - zenn-cli@0.4.0
+  - textlint@15.5.1
+  - textlint-rule-preset-ja-technical-writing@12.0.2
+  - textlint-rule-preset-ja-spacing@2.4.3
+  - @textlint-ja/*
+  - markdownlint (implied)
 
 ## 重要ルール
 - 会話言語: 日本語
@@ -42,28 +54,52 @@
 - TypeScript 使用時は `skipLibCheck` で回避しない。
 - 関数やインターフェースには docstring（JSDoc など）を記載する。
 
+### コーディング規約
+**markdown:**
+  - linting: markdownlint.jsonc with comprehensive rules
+  - format: GitHub Flavored Markdown
+**text:**
+  - linting: textlint with Japanese-specific rules
+  - rules: ['ja-technical-writing preset', 'ja-spacing preset', 'ja-no-inappropriate-words', 'smarthr preset', 'AI writing preset', 'prh (Japanese typo checker)']
+- **node_version**: Latest (from .node-version)
+
 ## 相談ルール
 - Codex CLI: 実装レビュー、局所設計、整合性確認に使う。
 - Gemini CLI: 外部仕様や最新情報の確認に使う。
 - 他エージェントの指摘は黙殺せず、採用または理由を明記して不採用とする。
 
-## 開発コマンド
+### 開発コマンド
 ```bash
-# 依存関係のインストール
+# install
 pnpm install
 
-# 開発 / テスト / Lint は README を確認してください
+# dev
+zenn preview --host 0.0.0.0
+
+# lint
+textlint articles/ books/
+
+# fix
+textlint --fix articles/ books/
+
 ```
 
-## アーキテクチャと主要ファイル
+### プロジェクト構造
+**ルートファイル:**
+- `package.json`
+- `.textlintrc`
+- `README.md`
 
 ## 実装パターン
+- 既存のコードパターンに従う。
+- プロジェクト固有の実装ガイドラインがある場合はそれに従う。
 
 ## テスト
 - 方針: 変更内容に応じてテストを追加する。
 
 ## ドキュメント更新ルール
 - 更新タイミング: 実装確定後、同一コミットまたは追加コミットで更新する。
+- README、API ドキュメント、コメント等は常に最新状態を保つ。
 
 ## 作業チェックリスト
 
@@ -94,3 +130,13 @@ pnpm install
 6. PR 本文の崩れがないことを確認する。
 
 ## リポジトリ固有
+- **note**: Zenn.dev documentation with Japanese content
+- **platform**: Zenn.dev publishing platform
+**content_types:**
+  - articles
+  - books
+- **language_focus**: Japanese
+**quality_focus:**
+  - Japanese grammar and spacing
+  - Technical writing standards
+  - Consistency and accessibility

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,19 @@
 - 日本語と英数字の間には半角スペースを入れる。
 
 ## プロジェクト概要
-- 目的: https://zenn.dev/book000
+Documentation repository for Zenn.dev that contains technical articles and books with Japanese language linting and quality checks.
+
+### 技術スタック
+- **言語**: Markdown, YAML
+- **フレームワーク**: Zenn CLI
+- **パッケージマネージャー**: pnpm
+- **主要な依存関係**:
+  - zenn-cli@0.4.0
+  - textlint@15.5.1
+  - textlint-rule-preset-ja-technical-writing@12.0.2
+  - textlint-rule-preset-ja-spacing@2.4.3
+  - @textlint-ja/*
+  - markdownlint (implied)
 
 ## コーディング規約
 - フォーマット: 既存設定（ESLint / Prettier / formatter）に従う。
@@ -23,12 +35,20 @@
 - コメント言語: 日本語
 - エラーメッセージ: 英語
 
-## 開発コマンド
+### 開発コマンド
 ```bash
-# 依存関係のインストール
+# install
 pnpm install
 
-# 開発 / テスト / Lint は README を確認してください
+# dev
+zenn preview --host 0.0.0.0
+
+# lint
+textlint articles/ books/
+
+# fix
+textlint --fix articles/ books/
+
 ```
 
 ## 注意事項
@@ -37,3 +57,13 @@ pnpm install
 - 既存のプロジェクトルールがある場合はそれを優先する。
 
 ## リポジトリ固有
+- **note**: Zenn.dev documentation with Japanese content
+- **platform**: Zenn.dev publishing platform
+**content_types:**
+  - articles
+  - books
+- **language_focus**: Japanese
+**quality_focus:**
+  - Japanese grammar and spacing
+  - Technical writing standards
+  - Consistency and accessibility


### PR DESCRIPTION
## Summary
- GitHub Copilot、Claude Code、Gemini CLI などの AI エージェント向けプロンプトファイルを追加しました
- `.github/copilot-instructions.md`: GitHub Copilot 向けの指示
- `CLAUDE.md`: Claude Code 向けの指示
- `AGENTS.md`: 一般的な AI エージェント向けの指示
- `GEMINI.md`: Gemini CLI 向けの指示

## Details
各ファイルには以下の情報が含まれています：
- プロジェクト概要
- 技術スタック（実際のコード分析に基づく）
- 開発コマンド
- アーキテクチャ
- コーディング規約

🤖 Generated with [Claude Code](https://claude.com/claude-code)