### PR TITLE
fix(textlint): resolve preset-ja-spacing v3 default-rule conflict

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -65,7 +65,13 @@
       "ja-space-around-code": {
         "before": true,
         "after": true
-      }
+      },
+      // v3 で追加された、プリセット内蔵の ja-space-around-link は既存記事のスペース規約と衝突するため無効化する
+      // （リンク前後のスペースは下の "ja-space-around-link" ルールで別途強制している）
+      "ja-space-around-link": false,
+      // v3 で新規追加されたルール。既存記事は未対応のため一旦無効化する
+      "ja-space-around-strong": false,
+      "ja-no-space-around-slash": false
     },
     // リンクの前後にはスペースを入れる
     "ja-space-around-link": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "textlint-rule-ja-space-around-link": "3.0.2",
     "textlint-rule-no-mixed-zenkaku-and-hankaku-alphabet": "1.0.1",
     "textlint-rule-preset-ai-writing": "1.1.0",
-    "textlint-rule-preset-ja-spacing": "2.4.3",
+    "textlint-rule-preset-ja-spacing": "3.0.2",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
     "textlint-rule-preset-smarthr": "1.37.5",
     "textlint-rule-prh": "6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0
       textlint-rule-preset-ja-spacing:
-        specifier: 2.4.3
-        version: 2.4.3
+        specifier: 3.0.2
+        version: 3.0.2
       textlint-rule-preset-ja-technical-writing:
         specifier: 12.0.2
         version: 12.0.2
@@ -1632,6 +1632,9 @@ packages:
   textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@2.4.3:
     resolution: {integrity: sha512-xIpEAgpaPTnavzCMLcSB/tlZ3Tq9paclyyMEgAQxkM9adv8TrwddZ+Ys+BSd4zjuVa94NED0bajYWtahSjZ53g==}
 
+  textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@3.0.2:
+    resolution: {integrity: sha512-jeWjD7gwV1zzO/el0fHaLP5Hu9ihvCJp5yjisaKk5s4w7jgoDKcT0aqyP2HFZd99bOrFWea0GecCFvJt6/B8ew==}
+
   textlint-rule-ja-no-abusage@3.0.0:
     resolution: {integrity: sha512-DIqPZgYTwTsvjX6Bgj7GA8vlwGMObagJpNoUtkucOaoy7E7GwUOL+knqFjcTtlkWSmoKpIkw5OWW5CV3kivlfQ==}
 
@@ -1650,8 +1653,17 @@ packages:
   textlint-rule-ja-no-space-around-parentheses@2.4.2:
     resolution: {integrity: sha512-DmmWEKu2hFJs/C4Ruxm/Zkp5gc9W+8kTgUULx54J00MJyJgLWm0XY9BH3OdN66+4+3BFutvxzCLU9y/M1+Dx7w==}
 
+  textlint-rule-ja-no-space-around-parentheses@3.0.2:
+    resolution: {integrity: sha512-/G1MNHo65kIhFFD+2/0CIZ5HuKa+GXkpHkUr3EREa2HQP52rzP8L6cwYfl+gtlEKZ8iCQMfN0SbPulodALVErw==}
+
+  textlint-rule-ja-no-space-around-slash@3.0.2:
+    resolution: {integrity: sha512-OdgDIh1AXxv8idIsWI6pN8xwTal+1Zb4033XKqxq7sZ7clk3CNqC5p+BUORUNMA/KeloYUo6o1lSGWPePmD+GQ==}
+
   textlint-rule-ja-no-space-between-full-width@2.4.2:
     resolution: {integrity: sha512-yDiZrJYX2cVO85tLw+ojUntky44ijEfIX2sWinIEN0IdYMCINjYwmgRYFmnqwQ+MZyo+foAt2vLUZtaSZlk/Lw==}
+
+  textlint-rule-ja-no-space-between-full-width@3.0.2:
+    resolution: {integrity: sha512-fQ1z01IgrG4HCuZUZ2YZiOXdBA4hQE92gbe+SXXKGjOYD+99mVq0nmqdjjRY3HPSy7IAcqlefKdK9DQ32FH85A==}
 
   textlint-rule-ja-no-successive-word@2.0.1:
     resolution: {integrity: sha512-XKTXkHwMu86SnGaj73B67U4apDdTquDKF3SfG24tRbzMyJoGe/Iba5VMId8sp8QHeTonp1bYOSxjZsbkpGyCNw==}
@@ -1662,20 +1674,35 @@ packages:
   textlint-rule-ja-space-after-exclamation@2.4.2:
     resolution: {integrity: sha512-3qH0aIG48MrA8qhcljGSGxPmvrrmOQsP/kTfj8SGDKdkBUs05z1x1bgw106RVNVv1enz2v+ZafuVdgFViRKWfA==}
 
+  textlint-rule-ja-space-after-exclamation@3.0.2:
+    resolution: {integrity: sha512-EiKXAD43vNVR7sWlCP1+QvMJQYSDpwxXodLOFHKWEYnUJACTm/54YBb8943oMhDbdWXPOVaBzU6XtX5lmBkIrw==}
+
   textlint-rule-ja-space-after-question@2.4.2:
     resolution: {integrity: sha512-ie1R03y1606QApXu+ZF6X+bAJLccRy/lA5JityfTO9M4EM+7ENMle9fTMoEEKJkNkjHaLi530IzqAZ+CLEe8Qw==}
+
+  textlint-rule-ja-space-after-question@3.0.2:
+    resolution: {integrity: sha512-t3aTXVX1ma/3V8E6G2mwkrHoLfu/3bTV4l6p6yySfOdb2wNiahmD08Cy71sD20CHzHxk57Ocx2OXFKKJx+9s2A==}
 
   textlint-rule-ja-space-around-code@2.4.2:
     resolution: {integrity: sha512-DM4OF7seafTKrxPFjUJyxx/lwlg8CO3wgwmTJWhQ+6po3mQVV6QaBHpc0861/32kUAJm1ZgRpiBlDWUdraXFFA==}
 
-  textlint-rule-ja-space-around-link@2.4.2:
-    resolution: {integrity: sha512-++o4wwCnDiubgE60QuOv0xW/0EcF2ta4EfjOycYsLYqvJ6DzFEZFGv3S/TujzmrIdRc8sHAO62489flvPu1DsQ==}
+  textlint-rule-ja-space-around-code@3.0.2:
+    resolution: {integrity: sha512-n9q9IBRie6ck3Bkapj+XMUT+lDD8lx0jH7YjIrDTzNRdIE76COF3NycMyhZm/o1i7tyQMggGarCmNaK1xcUKWg==}
+
+  textlint-rule-ja-space-around-emphasis@3.0.2:
+    resolution: {integrity: sha512-Oxut/HrzeamAaCw9Ll1vnYTi5YOKfWwL+dgnVeRKkJkDGIvpPgIer510HaovNHHAv2d3FzEkW3PxPKva4N3WUA==}
 
   textlint-rule-ja-space-around-link@3.0.2:
     resolution: {integrity: sha512-lh+7girFo0gt706/0bT3Yyf+QHdAnyaC8ybidbDN+NlDfkFi31qPdiFPrdTlQXwD9FfZelwBGAHVFAz22eoG4g==}
 
+  textlint-rule-ja-space-around-strong@3.0.2:
+    resolution: {integrity: sha512-uKxjaikPv8BuznFS7kPu8eqPGtOTiSpKw2+P8vf+bNbN2FzJq4RHXDjhhj2R5rUmIPPFgAcurDHPZ/A1WE66HQ==}
+
   textlint-rule-ja-space-between-half-and-full-width@2.4.2:
     resolution: {integrity: sha512-GqwSy0ivm4Q5Bok9LaOwfg+H1auLRMoMi2aY/7aSIrgvX/RD5aZ2Rk2lm3TTX42mR1UrQu8GDqktUEZfvQ913w==}
+
+  textlint-rule-ja-space-between-half-and-full-width@3.0.2:
+    resolution: {integrity: sha512-wdX0fCy7K7IBfxcflnEbkgx0j4mNQ7XRPGP7DFMHxJhqigZBkbrV/+uu2UwoBMxHd5CDJrPdxllrcrfNZoe4Ew==}
 
   textlint-rule-ja-unnatural-alphabet@2.0.1:
     resolution: {integrity: sha512-n93V8qh6OKdh8OB6yLT+9Xl8DSoZ7gWi51tWdhlLEPIWgBm18nLMgm6Ck+nVc3eENOdRcQURWUpCGotI8wTemA==}
@@ -1725,8 +1752,8 @@ packages:
   textlint-rule-preset-ai-writing@1.1.0:
     resolution: {integrity: sha512-bZEIdShA7RI0U1PkTA5K8PkDsh7LGs24nLQpnKgkfvcGfXEXZNRNGfS/b3oZQd4A4xydNCMKgk5M1+JKDKWFCQ==}
 
-  textlint-rule-preset-ja-spacing@2.4.3:
-    resolution: {integrity: sha512-WAiWY9TOE8/bRdl14XJdjkPQcV0hLS4O+PCUYU1yxXmJhZ8V3ciw2GYqpA9GL73qAxL25UD6mkf1yfz6aJ4qSA==}
+  textlint-rule-preset-ja-spacing@3.0.2:
+    resolution: {integrity: sha512-6uFVfqSBHjexMfTLO2jq/QOczSgYuPRVPgOsTrh60RItQiznk2oHAKL5rLdn0STty3fxqTx+6cFnkjqw4VaEkA==}
 
   textlint-rule-preset-ja-technical-writing@12.0.2:
     resolution: {integrity: sha512-BBVY6oA5V799k5wRfP+gCpDHsp6vWjWX2UT+/KLlAFFsNdmRB8Z6qyOnqiOjfzmLGIRgoMcPI1dXj5upOqnD6Q==}
@@ -3924,6 +3951,10 @@ snapshots:
     dependencies:
       textlint-rule-helper: 2.5.0
 
+  textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana@3.0.2:
+    dependencies:
+      textlint-rule-helper: 2.5.0
+
   textlint-rule-ja-no-abusage@3.0.0:
     dependencies:
       kuromojin: 3.0.1
@@ -3957,9 +3988,22 @@ snapshots:
       match-index: 1.0.3
       textlint-rule-helper: 2.5.0
 
+  textlint-rule-ja-no-space-around-parentheses@3.0.2:
+    dependencies:
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-no-space-around-slash@3.0.2:
+    dependencies:
+      textlint-rule-helper: 2.5.0
+
   textlint-rule-ja-no-space-between-full-width@2.4.2:
     dependencies:
       match-index: 1.0.3
+      regx: 1.0.4
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-no-space-between-full-width@3.0.2:
+    dependencies:
       regx: 1.0.4
       textlint-rule-helper: 2.5.0
 
@@ -3979,9 +4023,17 @@ snapshots:
       match-index: 1.0.3
       textlint-rule-helper: 2.5.0
 
+  textlint-rule-ja-space-after-exclamation@3.0.2:
+    dependencies:
+      textlint-rule-helper: 2.5.0
+
   textlint-rule-ja-space-after-question@2.4.2:
     dependencies:
       match-index: 1.0.3
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-space-after-question@3.0.2:
+    dependencies:
       textlint-rule-helper: 2.5.0
 
   textlint-rule-ja-space-around-code@2.4.2:
@@ -3989,12 +4041,19 @@ snapshots:
       match-index: 1.0.3
       textlint-rule-helper: 2.5.0
 
-  textlint-rule-ja-space-around-link@2.4.2:
+  textlint-rule-ja-space-around-code@3.0.2:
     dependencies:
-      match-index: 1.0.3
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-space-around-emphasis@3.0.2:
+    dependencies:
       textlint-rule-helper: 2.5.0
 
   textlint-rule-ja-space-around-link@3.0.2:
+    dependencies:
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-space-around-strong@3.0.2:
     dependencies:
       textlint-rule-helper: 2.5.0
 
@@ -4002,6 +4061,11 @@ snapshots:
     dependencies:
       '@textlint/regexp-string-matcher': 2.0.2
       match-index: 1.0.3
+      textlint-rule-helper: 2.5.0
+
+  textlint-rule-ja-space-between-half-and-full-width@3.0.2:
+    dependencies:
+      '@textlint/regexp-string-matcher': 2.0.2
       textlint-rule-helper: 2.5.0
 
   textlint-rule-ja-unnatural-alphabet@2.0.1:
@@ -4092,16 +4156,19 @@ snapshots:
       '@textlint/regexp-string-matcher': 2.0.2
       textlint-util-to-string: 3.3.4
 
-  textlint-rule-preset-ja-spacing@2.4.3:
+  textlint-rule-preset-ja-spacing@3.0.2:
     dependencies:
-      textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana: 2.4.3
-      textlint-rule-ja-no-space-around-parentheses: 2.4.2
-      textlint-rule-ja-no-space-between-full-width: 2.4.2
-      textlint-rule-ja-space-after-exclamation: 2.4.2
-      textlint-rule-ja-space-after-question: 2.4.2
-      textlint-rule-ja-space-around-code: 2.4.2
-      textlint-rule-ja-space-around-link: 2.4.2
-      textlint-rule-ja-space-between-half-and-full-width: 2.4.2
+      textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana: 3.0.2
+      textlint-rule-ja-no-space-around-parentheses: 3.0.2
+      textlint-rule-ja-no-space-around-slash: 3.0.2
+      textlint-rule-ja-no-space-between-full-width: 3.0.2
+      textlint-rule-ja-space-after-exclamation: 3.0.2
+      textlint-rule-ja-space-after-question: 3.0.2
+      textlint-rule-ja-space-around-code: 3.0.2
+      textlint-rule-ja-space-around-emphasis: 3.0.2
+      textlint-rule-ja-space-around-link: 3.0.2
+      textlint-rule-ja-space-around-strong: 3.0.2
+      textlint-rule-ja-space-between-half-and-full-width: 3.0.2
 
   textlint-rule-preset-ja-technical-writing@12.0.2:
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the CI failure introduced by #613 (`chore(deps): update dependency textlint-rule-preset-ja-spacing to v3`).

## Root cause

`textlint-rule-preset-ja-spacing` v3 flips the default (`rulesConfig`) of its
bundled `ja-space-around-link` sub-rule from `false` to `true`, and adds two
brand-new sub-rules (`ja-space-around-strong`, `ja-no-space-around-slash`)
that also default to `true`.

- The bundled `ja-space-around-link` (namespaced as
  `ja-spacing/ja-space-around-link`, options `{}`) now fires with opposite
  polarity to this repo's own separately-configured
  `ja-space-around-link` rule (`before: true, after: true`), which the
  existing articles already conform to. The two rules directly contradict
  each other, producing errors across most articles.
- `ja-space-around-strong` / `ja-no-space-around-slash` are new checks the
  existing article content was never written against.

None of this is a real content problem — it is a preset default-behavior
change unrelated to the dependency version bump itself.

## Fix

Explicitly disable these three sub-rules inside the `preset-ja-spacing`
block of `.textlintrc`, restoring the previous effective lint behavior
(same pattern already used there for `ja-space-around-code`).

After this change, `pnpm exec textlint articles/ books/` reports the same
`0 errors` baseline as before the bump (28 pre-existing `info`-level
suggestions only, unchanged).

## Note

I don't have push access to `book000/zenn-docs`, so this is opened from a
fork. This PR bumps `textlint-rule-preset-ja-spacing` to `3.0.2` itself
(same change as #613) plus the `.textlintrc` fix, so it can be merged
independently of #613.
